### PR TITLE
✨ Feat : connect frontend with backend

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -43,12 +43,14 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     # third-party
     "rest_framework",
+    "corsheaders",
     # apps
     "accounts",
     "chatbot",
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -74,6 +76,10 @@ TEMPLATES = [
             ],
         },
     },
+]
+
+CORS_ALLOWED_ORIGINS = [
+    env("LOCAL_FRONT_DOMAIN"),
 ]
 
 AUTH_USER_MODEL = "accounts.User"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ black==25.1.0
 click==8.1.8
 colorama==0.4.6
 Django==5.1.6
+django-cors-headers==4.7.0
 django-environ==0.12.0
 djangorestframework==3.15.2
 mypy-extensions==1.0.0


### PR DESCRIPTION
- CORS 설정 사용해서 프론트 연결

```
pip install django-cors-headers

혹은

pip install -r requirements.txt
```
패키지 설치 필요합니다!
일단 로컬 프론트 도메인 주소는 환경변수로 설정했는데 해당 부분은 슬랙으로 전달드리겠습니다
